### PR TITLE
Added tmPreferences file which allows commenting shortcut

### DIFF
--- a/Comments (FDS).tmPreferences
+++ b/Comments (FDS).tmPreferences
@@ -1,4 +1,4 @@
-<!-- <?xml version="1.0" encoding="UTF-8"?> -->
+<?xml version="1.0" encoding="UTF-8"?>
 <plist version="1.0">
 <dict>
 	<key>name</key>

--- a/Comments (FDS).tmPreferences
+++ b/Comments (FDS).tmPreferences
@@ -1,0 +1,21 @@
+<!-- <?xml version="1.0" encoding="UTF-8"?> -->
+<plist version="1.0">
+<dict>
+	<key>name</key>
+	<string>Comments</string>
+	<key>scope</key>
+	<string>source.fds</string>
+	<key>settings</key>
+	<dict>
+		<key>shellVariables</key>
+		<array>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_START</string>
+				<key>value</key>
+				<string>! </string>
+			</dict>
+		</array>
+	</dict>
+</dict>
+</plist>


### PR DESCRIPTION
Enables <kbd>SHIFT</kbd>+<kbd>/</kbd> comment shortcut in `.fds` files (`! ` used).

New file should simply be placed in same folder as `FDS.sublime-syntax`.